### PR TITLE
Update tag pattern for workflow trigger

### DIFF
--- a/.github/workflows/nuget-publish-on-tag.yml
+++ b/.github/workflows/nuget-publish-on-tag.yml
@@ -3,7 +3,7 @@ name: nuget-publish-tag
 on:
   push:
     tags: 
-      - '[0-9]+.[0-9]+.[0-9]+*'
+      - '[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   build:


### PR DESCRIPTION
Expanded the tag matching pattern in nuget-publish-on-tag.yml to allow zero or more digits in each version segment. This enables the workflow to trigger on a wider range of tag formats.