### PR TITLE
Switch to dotnet nuget push in publish workflow

### DIFF
--- a/.github/workflows/nuget-publish-on-tag.yml
+++ b/.github/workflows/nuget-publish-on-tag.yml
@@ -25,9 +25,6 @@ jobs:
         echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       shell: pwsh
 
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
-
     - name: Restore dependencies
       run: dotnet restore
 
@@ -47,4 +44,4 @@ jobs:
       
     - name: Publish
       if: startsWith(github.ref, 'refs/tags/')
-      run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+      run: dotnet nuget push **/*.nupkg -s 'https://api.nuget.org/v3/index.json' -k ${{secrets.NUGET_API_KEY}} --skip-duplicate


### PR DESCRIPTION
Replaced NuGet CLI with dotnet's built-in nuget push for package publishing. Added --skip-duplicate to prevent errors on duplicate uploads. Removed explicit NuGet setup step as it's no longer needed.